### PR TITLE
0.3.1

### DIFF
--- a/IntegrationSpecs/Tools/FileLoaderIntegrationSpec.swift
+++ b/IntegrationSpecs/Tools/FileLoaderIntegrationSpec.swift
@@ -4,12 +4,12 @@ import Capsule
 @testable import Utensils
 
 final class FileLoaderIntegrationSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("FileLoader") {
             var subject: FileLoader!
             
             beforeEach {
-                let testBundle = Bundle(for: type(of: self))
+                let testBundle = Bundle(for: self)
                 
                 subject = FileLoader(bundle: testBundle)
             }

--- a/IntegrationSpecs/Tools/PequenoNetworking/PequenoNetworkingIntegrationSpec.swift
+++ b/IntegrationSpecs/Tools/PequenoNetworking/PequenoNetworkingIntegrationSpec.swift
@@ -3,8 +3,8 @@ import Moocher
 import Capsule
 @testable import Utensils
 
-final class PequenoNetworkingV2IntegrationSpec: QuickSpec {
-    override func spec() {
+final class PequenoNetworkingIntegrationSpec: QuickSpec {
+    override class func spec() {
         describe("PequenoNetworking") {
             var subject: PequenoNetworking!
             

--- a/IntegrationSpecs/Tools/PequenoNetworking/PequenoNetworkingIntegrationSpec.swift
+++ b/IntegrationSpecs/Tools/PequenoNetworking/PequenoNetworkingIntegrationSpec.swift
@@ -8,25 +8,25 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
         describe("PequenoNetworking") {
             var subject: PequenoNetworking!
             
+            beforeEach {
+                subject = PequenoNetworking(baseURL: "https://httpbin.org",
+                                            headers: nil)
+            }
+            
             describe("using JSONSerialization") {
                 describe("GET request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.get(endpoint: "/get",
                                         parameters: nil) { result in
                                 if case .success(let jsonResponse) = result {
-                                    guard let quotes = jsonResponse as? [String: Any] else {
+                                    guard let jsonResponse = jsonResponse as? [String: Any] else {
                                         failSpec()
                                         
                                         return
                                     }
                                     
-                                    expect(quotes).toNot.beEmpty()
+                                    expect(jsonResponse).toNot.beEmpty()
                                 } else {
                                     failSpec()
                                 }
@@ -38,23 +38,18 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                 }
                 
                 describe("DELETE request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(20)) { complete in
                             subject.delete(endpoint: "/delete",
                                            parameters: nil) { result in
                                 if case .success(let jsonResponse) = result {
-                                    guard let quotes = jsonResponse as? [String: Any] else {
+                                    guard let jsonResponse = jsonResponse as? [String: Any] else {
                                         failSpec()
                                         
                                         return
                                     }
                                     
-                                    expect(quotes).toNot.beEmpty()
+                                    expect(jsonResponse).toNot.beEmpty()
                                 } else {
                                     failSpec()
                                 }
@@ -66,23 +61,18 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                 }
                 
                 describe("POST request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.post(endpoint: "/post",
                                          body: nil) { result in
                                 if case .success(let jsonResponse) = result {
-                                    guard let quotes = jsonResponse as? [String: Any] else {
+                                    guard let jsonResponse = jsonResponse as? [String: Any] else {
                                         failSpec()
                                         
                                         return
                                     }
                                     
-                                    expect(quotes).toNot.beEmpty()
+                                    expect(jsonResponse).toNot.beEmpty()
                                 } else {
                                     failSpec()
                                 }
@@ -94,23 +84,18 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                 }
                 
                 describe("PUT request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.put(endpoint: "/put",
                                         body: nil) { result in
                                 if case .success(let jsonResponse) = result {
-                                    guard let quotes = jsonResponse as? [String: Any] else {
+                                    guard let jsonResponse = jsonResponse as? [String: Any] else {
                                         failSpec()
                                         
                                         return
                                     }
                                     
-                                    expect(quotes).toNot.beEmpty()
+                                    expect(jsonResponse).toNot.beEmpty()
                                 } else {
                                     failSpec()
                                 }
@@ -122,23 +107,18 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                 }
                 
                 describe("PATCH request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.patch(endpoint: "/patch",
                                           body: nil) { result in
                                 if case .success(let jsonResponse) = result {
-                                    guard let quotes = jsonResponse as? [String: Any] else {
+                                    guard let jsonResponse = jsonResponse as? [String: Any] else {
                                         failSpec()
                                         
                                         return
                                     }
                                     
-                                    expect(quotes).toNot.beEmpty()
+                                    expect(jsonResponse).toNot.beEmpty()
                                 } else {
                                     failSpec()
                                 }
@@ -152,11 +132,6 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
             
             describe("using Codable") {
                 describe("GET request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.get(endpoint: "/get",
@@ -174,11 +149,6 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                 }
                 
                 describe("DELETE request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.delete(endpoint: "/delete",
@@ -196,11 +166,6 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                 }
                 
                 describe("POST request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.post(endpoint: "/post",
@@ -218,11 +183,6 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                 }
                 
                 describe("PUT request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.put(endpoint: "/put",
@@ -240,11 +200,6 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                 }
                 
                 describe("PATCH request") {
-                    beforeEach {
-                        subject = PequenoNetworking(baseURL: "https://httpbin.org",
-                                                    headers: nil)
-                    }
-                    
                     it("completes with deserialized json") {
                         hangOn(for: .seconds(5)) { complete in
                             subject.patch(endpoint: "/patch",
@@ -278,13 +233,13 @@ final class PequenoNetworkingIntegrationSpec: QuickSpec {
                         subject.get(endpoint: "/get",
                                     parameters: nil) { result in
                             if case .success(let jsonResponse) = result {
-                                guard let quotes = jsonResponse as? [String: Any] else {
+                                guard let jsonResponse = jsonResponse as? [String: Any] else {
                                     failSpec()
                                     
                                     return
                                 }
                                 
-                                expect(quotes).toNot.beEmpty()
+                                expect(jsonResponse).toNot.beEmpty()
                             } else {
                                 failSpec()
                             }

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '12.0'
 use_frameworks!
 inhibit_all_warnings!
 
@@ -9,6 +8,7 @@ def shared_pods
 end
 
 target :Utensils do
+  platform :ios, '12.0'
   shared_pods
 
   pod 'SwiftLint', '0.54.0'
@@ -17,15 +17,17 @@ end
 def shared_spec_pods
   shared_pods
 
-  pod 'Quick', '5.0.1'
+  pod 'Quick', '7.3.0'
   pod 'Moocher', '0.4.0'
 end
 
 target :Specs do
+  platform :ios, '15.0'
   shared_spec_pods
 end
 
 target :IntegrationSpecs do
+  platform :ios, '15.0'
   shared_spec_pods
 
   pod 'Moocher/Polling', '0.4.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
     - Moocher/Core (= 0.4.0)
   - Moocher/Core (0.4.0)
   - Moocher/Polling (0.4.0)
-  - Quick (5.0.1)
+  - Quick (7.3.0)
   - SwiftLint (0.54.0)
 
 DEPENDENCIES:
   - Capsule (= 1.4.0)
   - Moocher (= 0.4.0)
   - Moocher/Polling (= 0.4.0)
-  - Quick (= 5.0.1)
+  - Quick (= 7.3.0)
   - SwiftLint (= 0.54.0)
 
 SPEC REPOS:
@@ -24,9 +24,9 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Capsule: 51717c6fb9beac5c66f9cd824a0d8083ec45b52c
   Moocher: 4c5f38df3caf6d4664e525a7e119584ad6614680
-  Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
+  Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 4f6a38406f7a320c3f68b5265bc7a788243dc0f6
+PODFILE CHECKSUM: c29fea0ce880c51a57cb34e38742a7c2ddea657f
 
 COCOAPODS: 1.14.3

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A set of useful iOS tools.
 
 [Swift Package Manager](https://swift.org/package-manager/) can be used to add `Utensils` the to your project:
 
-1.  Add `.package(url: "https://github.com/rbaumbach/Utensils", from: "0.3.0")`
+1.  Add `.package(url: "https://github.com/rbaumbach/Utensils", from: "0.3.1")`
 2.  [Follow intructions to add](https://swift.org/getting-started/#using-the-package-manager) the Utensils package to your project.
 
 ### Clone from Github

--- a/Sources/Utensils/Tools/Fakes/FakeDebouncer.swift
+++ b/Sources/Utensils/Tools/Fakes/FakeDebouncer.swift
@@ -28,6 +28,10 @@ public class FakeDebouncer: DebouncerProtocol {
     public var capturedDebounceSeconds: Double?
     public var capturedDebounceExectution: (() -> Void)?
     
+    // MARK: - Public properties
+    
+    public var shouldExecuteImmediately = false
+    
     // MARK: - Init methods
     
     public init() { }
@@ -37,5 +41,9 @@ public class FakeDebouncer: DebouncerProtocol {
     public func mainDebounce(seconds: Double, execute: @escaping () -> Void) {
         capturedDebounceSeconds = seconds
         capturedDebounceExectution = execute
+        
+        if shouldExecuteImmediately {
+            execute()
+        }
     }
 }

--- a/Sources/Utensils/Tools/Fakes/FakeFileLoader.swift
+++ b/Sources/Utensils/Tools/Fakes/FakeFileLoader.swift
@@ -30,10 +30,12 @@ public class FakeFileLoader: FileLoaderProtocol {
     public var capturedLoadJSONFileExtension: String?
     
     // MARK: - Stubbed properties
+        
+    public var stubbedLoadJSON: Any?
+    
+    // MARK: - Public properties
     
     public var shouldThrowErrorLoadingJSON = false
-    
-    public var stubbedLoadJSON: Any?
     
     // MARK: - Init methods
     

--- a/Sources/Utensils/Tools/Fakes/FakeTrunk.swift
+++ b/Sources/Utensils/Tools/Fakes/FakeTrunk.swift
@@ -53,6 +53,12 @@ public class FakeTrunk: TrunkProtocol {
     
     public var stubbedLoadData: Any?
     
+    public var stubbedLoadDataForCompletionHandler: Any = "data"
+    
+    // MARK: - Public properties
+    
+    public var shouldExecuteCompletionHandlersImmediately = false
+    
     // MARK: - Init methods
     
     public init() { }
@@ -79,31 +85,43 @@ public class FakeTrunk: TrunkProtocol {
         }
     }
     
-    public func save<T: Codable>(data: T, directory: Directory, filename: String) {
+    public func save<T: Codable>(data: T, 
+                                 directory: Directory,
+                                 filename: String) {
         capturedSaveData = data
         capturedSaveDirectory = directory
         capturedSaveFilename = filename
     }
     
-    public func save<T: Codable>(data: T, directory: Directory, filename: String, completionHandler: @escaping () -> Void) {
+    public func save<T: Codable>(data: T, 
+                                 directory: Directory,
+                                 filename: String,
+                                 completionHandler: @escaping () -> Void) {
         capturedSaveDataAsync = data
         capturedSaveDirectoryAsync = directory
         capturedSaveFilenameAsync = filename
         capturedSaveCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler()
+        }
     }
     
-    public func load<T: Codable>(directory: Directory, filename: String) -> T? {
+    public func load<T: Codable>(directory: Directory, 
+                                 filename: String) -> T? {
+        capturedLoadDirectory = directory
+        capturedLoadFilename = filename
+        
         guard let stubbedLoadData = stubbedLoadData else {
             return nil
         }
-        
-        capturedLoadDirectory = directory
-        capturedLoadFilename = filename
                 
         return stubbedLoadData as? T
     }
     
-    public func load<T: Codable>(directory: Directory, filename: String, completionHandler: @escaping (T?) -> Void) {
+    public func load<T: Codable>(directory: Directory, 
+                                 filename: String,
+                                 completionHandler: @escaping (T?) -> Void) {
         capturedLoadDirectoryAsync = directory
         capturedLoadFilenameAsync = filename
         
@@ -118,5 +136,9 @@ public class FakeTrunk: TrunkProtocol {
         }
         
         capturedLoadCompletionHandler = anyCompletionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedLoadDataForCompletionHandler as? T)
+        }
     }
 }

--- a/Sources/Utensils/Tools/PequenoNetworking/Fakes/FakeClassicNetworkingEngine.swift
+++ b/Sources/Utensils/Tools/PequenoNetworking/Fakes/FakeClassicNetworkingEngine.swift
@@ -55,6 +55,18 @@ public class FakeClassicNetworkingEngine: ClassicNetworkingEngineProtocol {
     public var capturedPatchBody: [String: Any]?
     public var capturedPatchCompletionHandler: ((Result<Any, PequenoNetworking.Error>) -> Void)?
     
+    // MARK: - Stubbed properties
+        
+    public var stubbedGetResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedDeleteResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPostResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPutResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPatchResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    
+    // MARK: - Public properties
+    
+    public var shouldExecuteCompletionHandlersImmediately = false
+    
     // MARK: - Init methods
     
     public init() { }
@@ -71,6 +83,10 @@ public class FakeClassicNetworkingEngine: ClassicNetworkingEngineProtocol {
         capturedGetEndpoint = endpoint
         capturedGetParameters = parameters
         capturedGetCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedGetResult)
+        }
     }
     
     public func delete(baseURL: String,
@@ -83,6 +99,10 @@ public class FakeClassicNetworkingEngine: ClassicNetworkingEngineProtocol {
         capturedDeleteEndpoint = endpoint
         capturedDeleteParameters = parameters
         capturedDeleteCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedDeleteResult)
+        }
     }
     
     public func post(baseURL: String,
@@ -95,6 +115,10 @@ public class FakeClassicNetworkingEngine: ClassicNetworkingEngineProtocol {
         capturedPostEndpoint = endpoint
         capturedPostBody = body
         capturedPostCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedPostResult)
+        }
     }
     
     public func put(baseURL: String,
@@ -107,6 +131,10 @@ public class FakeClassicNetworkingEngine: ClassicNetworkingEngineProtocol {
         capturedPutEndpoint = endpoint
         capturedPutBody = body
         capturedPutCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedPutResult)
+        }
     }
     
     public func patch(baseURL: String,
@@ -119,5 +147,9 @@ public class FakeClassicNetworkingEngine: ClassicNetworkingEngineProtocol {
         capturedPatchEndpoint = endpoint
         capturedPatchBody = body
         capturedPatchCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedPatchResult)
+        }
     }
 }

--- a/Sources/Utensils/Tools/PequenoNetworking/Fakes/FakeNetworkingEngine.swift
+++ b/Sources/Utensils/Tools/PequenoNetworking/Fakes/FakeNetworkingEngine.swift
@@ -58,6 +58,18 @@ public class FakeNetworkingEngine: NetworkingEngineProtocol {
     public var capturedPatchBody: [String: Any]?
     public var capturedPatchCompletionHandler: Any?
     
+    // MARK: - Stubbed properties
+    
+    public var stubbedGetResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedDeleteResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPostResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPutResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPatchResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    
+    // MARK: - Public properties
+    
+    public var shouldExecuteCompletionHandlersImmediately = false
+    
     // MARK: - Init methods
     
     public init() { }
@@ -73,8 +85,15 @@ public class FakeNetworkingEngine: NetworkingEngineProtocol {
         capturedGetHeaders = headers
         capturedGetEndpoint = endpoint
         capturedGetParameters = parameters
-        
         capturedGetCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedGetResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable get result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
     }
     
     public func delete<T: Codable>(baseURL: String,
@@ -87,6 +106,14 @@ public class FakeNetworkingEngine: NetworkingEngineProtocol {
         capturedDeleteEndpoint = endpoint
         capturedDeleteParameters = parameters
         capturedDeleteCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedDeleteResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable delete result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
     }
     
     public func post<T: Codable>(baseURL: String,
@@ -99,6 +126,14 @@ public class FakeNetworkingEngine: NetworkingEngineProtocol {
         capturedPostEndpoint = endpoint
         capturedPostBody = body
         capturedPostCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedPostResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable post result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
     }
     
     public func put<T: Codable>(baseURL: String,
@@ -111,6 +146,14 @@ public class FakeNetworkingEngine: NetworkingEngineProtocol {
         capturedPutEndpoint = endpoint
         capturedPutBody = body
         capturedPutCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedPutResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable put result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
     }
     
     public func patch<T: Codable>(baseURL: String,
@@ -123,5 +166,13 @@ public class FakeNetworkingEngine: NetworkingEngineProtocol {
         capturedPatchEndpoint = endpoint
         capturedPatchBody = body
         capturedPatchCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedPatchResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable patch result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
     }
 }

--- a/Sources/Utensils/Tools/PequenoNetworking/Fakes/FakePequenoNetworking.swift
+++ b/Sources/Utensils/Tools/PequenoNetworking/Fakes/FakePequenoNetworking.swift
@@ -1,0 +1,243 @@
+//MIT License
+//
+//Copyright (c) 2020-2024 Ryan Baumbach <github@ryan.codes>
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+import Foundation
+
+public class FakePequenoNetworking: PequenoNetworkingProtocol {
+    // MARK: - Captured properties
+    
+    // MARK: - JSONSerialization (ol' skoo)
+    
+    public var capturedGetEndpoint: String?
+    public var capturedGetParameters: [String: String]?
+    public var capturedGetCompletionHandler: ((Result<Any, PequenoNetworking.Error>) -> Void)?
+    
+    public var capturedDeleteEndpoint: String?
+    public var capturedDeleteParameters: [String: String]?
+    public var capturedDeleteCompletionHandler: ((Result<Any, PequenoNetworking.Error>) -> Void)?
+    
+    public var capturedPostEndpoint: String?
+    public var capturedPostBody: [String: Any]?
+    public var capturedPostCompletionHandler: ((Result<Any, PequenoNetworking.Error>) -> Void)?
+    
+    public var capturedPutEndpoint: String?
+    public var capturedPutBody: [String: Any]?
+    public var capturedPutCompletionHandler: ((Result<Any, PequenoNetworking.Error>) -> Void)?
+    
+    public var capturedPatchEndpoint: String?
+    public var capturedPatchBody: [String: Any]?
+    public var capturedPatchCompletionHandler: ((Result<Any, PequenoNetworking.Error>) -> Void)?
+    
+    // MARK: - Codable
+    
+    public var capturedCodableGetEndpoint: String?
+    public var capturedCodableGetParameters: [String: String]?
+    public var capturedCodableGetCompletionHandler: Any?
+    
+    public var capturedCodableDeleteEndpoint: String?
+    public var capturedCodableDeleteParameters: [String: String]?
+    public var capturedCodableDeleteCompletionHandler: Any?
+    
+    public var capturedCodablePostEndpoint: String?
+    public var capturedCodablePostBody: [String: Any]?
+    public var capturedCodablePostCompletionHandler: Any?
+    
+    public var capturedCodablePutEndpoint: String?
+    public var capturedCodablePutBody: [String: Any]?
+    public var capturedCodablePutCompletionHandler: Any?
+    
+    public var capturedCodablePatchEndpoint: String?
+    public var capturedCodablePatchBody: [String: Any]?
+    public var capturedCodablePatchCompletionHandler: Any?
+    
+    // MARK: - Stubbed properties
+    
+    // MARK: - JSONSerialization (ol' skoo)
+    
+    public var stubbedGetResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedDeleteResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPostResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPutResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedPatchResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    
+    // MARK: - Codable
+    
+    public var stubbedCodableGetResult: Any = Result<Any, PequenoNetworking.Error>.success("Éxito")
+    public var stubbedCodableDeleteResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedCodablePostResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedCodablePutResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    public var stubbedCodablePatchResult: Result<Any, PequenoNetworking.Error> = .success("Éxito")
+    
+    // MARK: - Public properties
+    
+    public var shouldExecuteCompletionHandlersImmediately = false
+    
+    // MARK: - Init methods
+    
+    public init() { }
+    
+    // MARK: - <PequenoNetworkingProtocol>
+    
+    // MARK: - JSONSerialization (ol' skoo)
+    
+    public func get(endpoint: String,
+                    parameters: [String: String]?,
+                    completionHandler: @escaping (Result<Any, PequenoNetworking.Error>) -> Void) {
+        capturedGetEndpoint = endpoint
+        capturedGetParameters = parameters
+        capturedGetCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedGetResult)
+        }
+    }
+    
+    public func delete(endpoint: String,
+                       parameters: [String: String]?,
+                       completionHandler: @escaping (Result<Any, PequenoNetworking.Error>) -> Void) {
+        capturedDeleteEndpoint = endpoint
+        capturedDeleteParameters = parameters
+        capturedDeleteCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedDeleteResult)
+        }
+    }
+    
+    public func post(endpoint: String,
+                     body: [String: Any]?,
+                     completionHandler: @escaping (Result<Any, PequenoNetworking.Error>) -> Void) {
+        capturedPostEndpoint = endpoint
+        capturedPostBody = body
+        capturedPostCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedPostResult)
+        }
+    }
+    
+    public func put(endpoint: String,
+                    body: [String: Any]?,
+                    completionHandler: @escaping (Result<Any, PequenoNetworking.Error>) -> Void) {
+        capturedPutEndpoint = endpoint
+        capturedPutBody = body
+        capturedPutCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedPutResult)
+        }
+    }
+    
+    public func patch(endpoint: String,
+                      body: [String: Any]?,
+                      completionHandler: @escaping (Result<Any, PequenoNetworking.Error>) -> Void) {
+        capturedPatchEndpoint = endpoint
+        capturedPatchBody = body
+        capturedPatchCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            completionHandler(stubbedPatchResult)
+        }
+    }
+    
+    // MARK: - <NetworkingEngineProtocol>
+    
+    public func get<T: Codable>(endpoint: String,
+                                parameters: [String: String]?,
+                                completionHandler: @escaping (Result<T, PequenoNetworking.Error>) -> Void) {
+        capturedCodableGetEndpoint = endpoint
+        capturedCodableGetParameters = parameters
+        capturedCodableGetCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedCodableGetResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable get result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
+    }
+    
+    public func delete<T: Codable>(endpoint: String,
+                                   parameters: [String: String]?,
+                                   completionHandler: @escaping (Result<T, PequenoNetworking.Error>) -> Void) {
+        capturedCodableDeleteEndpoint = endpoint
+        capturedCodableDeleteParameters = parameters
+        capturedCodableDeleteCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedCodableDeleteResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable delete result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
+    }
+    
+    public func post<T: Codable>(endpoint: String,
+                                 body: [String: Any]?,
+                                 completionHandler: @escaping (Result<T, PequenoNetworking.Error>) -> Void) {
+        capturedCodablePostEndpoint = endpoint
+        capturedCodablePostBody = body
+        capturedCodablePostCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedCodablePostResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable post result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
+    }
+    
+    public func put<T: Codable>(endpoint: String,
+                                body: [String: Any]?,
+                                completionHandler: @escaping (Result<T, PequenoNetworking.Error>) -> Void) {
+        capturedCodablePutEndpoint = endpoint
+        capturedCodablePutBody = body
+        capturedCodablePutCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedCodablePutResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable put result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
+    }
+    
+    public func patch<T: Codable>(endpoint: String,
+                                  body: [String: Any]?,
+                                  completionHandler: @escaping (Result<T, PequenoNetworking.Error>) -> Void) {
+        capturedCodablePatchEndpoint = endpoint
+        capturedCodablePatchBody = body
+        capturedCodablePatchCompletionHandler = completionHandler
+        
+        if shouldExecuteCompletionHandlersImmediately {
+            guard let typedStubbedResult = stubbedCodablePatchResult as? Result<T, PequenoNetworking.Error> else {
+                preconditionFailure("The stubbed codable patch result is not the correct type")
+            }
+            
+            completionHandler(typedStubbedResult)
+        }
+    }
+}

--- a/Specs/Models/DirectorySpec.swift
+++ b/Specs/Models/DirectorySpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class DirectorySpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("Directory") {
             var subject: Directory!
             

--- a/Specs/Tools/DebouncerSpec.swift
+++ b/Specs/Tools/DebouncerSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class DebouncerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("Debouncer") {
             var subject: Debouncer!
             

--- a/Specs/Tools/FileLoader/FileLoader+UtensilsSpec.swift
+++ b/Specs/Tools/FileLoader/FileLoader+UtensilsSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class FileLoader_UtensilsSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("FileLoader+Utensils") {
             describe("<CaseIterable>)") {
                 it("has all required cases") {

--- a/Specs/Tools/FileLoader/FileLoaderSpec.swift
+++ b/Specs/Tools/FileLoader/FileLoaderSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class FileLoaderSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("FileLoader") {
             var subject: FileLoader!
             

--- a/Specs/Tools/PequenoNetworking/Engine/ClassicNetworkingEngineSpec.swift
+++ b/Specs/Tools/PequenoNetworking/Engine/ClassicNetworkingEngineSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class ClassicNetworkingEngineSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("ClassicNetworkingEngine") {
             var subject: ClassicNetworkingEngine!
             

--- a/Specs/Tools/PequenoNetworking/Engine/NetworkingEngineSpec.swift
+++ b/Specs/Tools/PequenoNetworking/Engine/NetworkingEngineSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class NetworkingEngineSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("NetworkingEngine") {
             var subject: NetworkingEngine!
             

--- a/Specs/Tools/PequenoNetworking/Engine/URLSessionExecutorSpec.swift
+++ b/Specs/Tools/PequenoNetworking/Engine/URLSessionExecutorSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class URLSessionExecutorSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("URLSessionExecutor") {
             var subject: URLSessionExecutor!
             var fakeURLSession: FakeURLSession!

--- a/Specs/Tools/PequenoNetworking/Models/HTTPMethodSpec.swift
+++ b/Specs/Tools/PequenoNetworking/Models/HTTPMethodSpec.swift
@@ -3,7 +3,7 @@ import Moocher
 @testable import Utensils
 
 final class HTTPMethodSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("HTTPMethod") {
             it("has proper raw values") {
                 expect(HTTPMethod.get.rawValue).to.equal("GET")

--- a/Specs/Tools/PequenoNetworking/Models/URLRequestBuilderSpec.swift
+++ b/Specs/Tools/PequenoNetworking/Models/URLRequestBuilderSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class URLRequestBuilderSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("URLRequestBuilder") {
             var subject: URLRequestBuilder!
             var fakeJSONSerializationWrapper: FakeJSONSerializationWrapper!

--- a/Specs/Tools/PequenoNetworking/Models/URLRequestInfoSpec.swift
+++ b/Specs/Tools/PequenoNetworking/Models/URLRequestInfoSpec.swift
@@ -3,7 +3,7 @@ import Moocher
 @testable import Utensils
 
 final class URLRequestInfoSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("URLRequestInfo") {
             var subject: URLRequestInfo!
             

--- a/Specs/Tools/PequenoNetworking/PequenoNetworking+UtensilsSpec.swift
+++ b/Specs/Tools/PequenoNetworking/PequenoNetworking+UtensilsSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class PequenoNetworking_UtensilsSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("PequenoNetworking+Utensils") {
             var emptyURLRequestInfo: URLRequestInfo!
             

--- a/Specs/Tools/PequenoNetworking/PequenoNetworkingConstantsSpec.swift
+++ b/Specs/Tools/PequenoNetworking/PequenoNetworkingConstantsSpec.swift
@@ -3,7 +3,7 @@ import Moocher
 @testable import Utensils
 
 final class PequenoNetworkingConstantsSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("PequenoNetworkingConstants") {
             it("has all required constants") {
                 expect(PequenoNetworkingConstants.BaseURLKey).to.equal("PequenoNetworkingBaseURLKey")

--- a/Specs/Tools/PequenoNetworking/PequenoNetworkingSpec.swift
+++ b/Specs/Tools/PequenoNetworking/PequenoNetworkingSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class PequenoNetworkingSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("PequenoNetworking") {
             var subject: PequenoNetworking!
             

--- a/Specs/Tools/Trunk/TrunkSpec.swift
+++ b/Specs/Tools/Trunk/TrunkSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class TrunkSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("Trunk") {
             var subject: Trunk!
 

--- a/Specs/Tools/ValidatorSpec.swift
+++ b/Specs/Tools/ValidatorSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class ValidatorSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("Validator") {
             var subject: AnyValidator<Dog>!
 

--- a/Specs/ViewControllers/AppLaunchViewControllerSpec.swift
+++ b/Specs/ViewControllers/AppLaunchViewControllerSpec.swift
@@ -4,7 +4,7 @@ import Capsule
 @testable import Utensils
 
 final class AppLaunchViewControllerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("AppLaunchViewController") {
             var subject: AppLaunchViewController!
             

--- a/Utensils.podspec
+++ b/Utensils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name                  = 'Utensils'
-  spec.version               = '0.3.0'
+  spec.version               = '0.3.1'
   spec.summary               = 'A set of useful iOS tools.'
   spec.homepage              = 'https://github.com/rbaumbach/utensils'
   spec.license               = { :type => 'MIT', :file => 'MIT-LICENSE.txt' }

--- a/Utensils.xcodeproj/project.pbxproj
+++ b/Utensils.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		94569E152B274845008494E1 /* FileLoaderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94569E142B274845008494E1 /* FileLoaderSpec.swift */; };
 		94569E172B28E279008494E1 /* SomeTestFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94569E162B28E279008494E1 /* SomeTestFunctions.swift */; };
 		94569E202B28EC93008494E1 /* Utensils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94341AF9238CCECF00BC8355 /* Utensils.framework */; platformFilter = ios; };
-		94569E282B28EE64008494E1 /* FileLoaderIntegrationSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94569E272B28EE64008494E1 /* FileLoaderIntegrationSpecs.swift */; };
+		94569E282B28EE64008494E1 /* FileLoaderIntegrationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94569E272B28EE64008494E1 /* FileLoaderIntegrationSpec.swift */; };
 		94569E2E2B28F655008494E1 /* file.json in Resources */ = {isa = PBXBuildFile; fileRef = 94569E2A2B28EF10008494E1 /* file.json */; };
 		94569E302B29F596008494E1 /* FakeFileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94569E2F2B29F596008494E1 /* FakeFileLoader.swift */; };
 		94569E372B2CB1EE008494E1 /* FileLoader+Utensils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94569E362B2CB1EE008494E1 /* FileLoader+Utensils.swift */; };
@@ -55,7 +55,7 @@
 		94872AF52915D16F00D3528B /* AppLaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94872AF32915D16F00D3528B /* AppLaunchViewController.swift */; };
 		94872AF92915D20700D3528B /* Bundle+Utensils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94872AF82915D20700D3528B /* Bundle+Utensils.swift */; };
 		94872AFF2915D28E00D3528B /* Trunk+Utensils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94872AFE2915D28E00D3528B /* Trunk+Utensils.swift */; };
-		94B2AE712B3740900081B1FE /* PequenoNetworkingIntegrationSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B2AE702B3740900081B1FE /* PequenoNetworkingIntegrationSpecs.swift */; };
+		94B2AE712B3740900081B1FE /* PequenoNetworkingIntegrationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B2AE702B3740900081B1FE /* PequenoNetworkingIntegrationSpec.swift */; };
 		94DB4641239479EF00D0C0A2 /* AppLaunchViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB4640239479EF00D0C0A2 /* AppLaunchViewControllerSpec.swift */; };
 		94FD50582B3B24770090455F /* URLRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94FD50572B3B24770090455F /* URLRequestBuilder.swift */; };
 		94FD505B2B3B26020090455F /* URLRequestBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94FD505A2B3B26020090455F /* URLRequestBuilderSpec.swift */; };
@@ -82,6 +82,19 @@
 			remoteInfo = Utensils;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9404C5872B43BD20001626C8 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0F65C3E235F028D5409A1E1C /* Pods-Utensils.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Utensils.debug.xcconfig"; path = "Target Support Files/Pods-Utensils/Pods-Utensils.debug.xcconfig"; sourceTree = "<group>"; };
@@ -118,7 +131,7 @@
 		94569E142B274845008494E1 /* FileLoaderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLoaderSpec.swift; sourceTree = "<group>"; };
 		94569E162B28E279008494E1 /* SomeTestFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeTestFunctions.swift; sourceTree = "<group>"; };
 		94569E1C2B28EC93008494E1 /* IntegrationSpecs.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationSpecs.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		94569E272B28EE64008494E1 /* FileLoaderIntegrationSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLoaderIntegrationSpecs.swift; sourceTree = "<group>"; };
+		94569E272B28EE64008494E1 /* FileLoaderIntegrationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLoaderIntegrationSpec.swift; sourceTree = "<group>"; };
 		94569E2A2B28EF10008494E1 /* file.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = file.json; sourceTree = "<group>"; };
 		94569E2F2B29F596008494E1 /* FakeFileLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeFileLoader.swift; sourceTree = "<group>"; };
 		94569E362B2CB1EE008494E1 /* FileLoader+Utensils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileLoader+Utensils.swift"; sourceTree = "<group>"; };
@@ -139,7 +152,7 @@
 		94872AF32915D16F00D3528B /* AppLaunchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppLaunchViewController.swift; sourceTree = "<group>"; };
 		94872AF82915D20700D3528B /* Bundle+Utensils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Utensils.swift"; sourceTree = "<group>"; };
 		94872AFE2915D28E00D3528B /* Trunk+Utensils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Trunk+Utensils.swift"; sourceTree = "<group>"; };
-		94B2AE702B3740900081B1FE /* PequenoNetworkingIntegrationSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PequenoNetworkingIntegrationSpecs.swift; sourceTree = "<group>"; };
+		94B2AE702B3740900081B1FE /* PequenoNetworkingIntegrationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PequenoNetworkingIntegrationSpec.swift; sourceTree = "<group>"; };
 		94DB4640239479EF00D0C0A2 /* AppLaunchViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchViewControllerSpec.swift; sourceTree = "<group>"; };
 		94FD50572B3B24770090455F /* URLRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestBuilder.swift; sourceTree = "<group>"; };
 		94FD505A2B3B26020090455F /* URLRequestBuilderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestBuilderSpec.swift; sourceTree = "<group>"; };
@@ -334,7 +347,7 @@
 			isa = PBXGroup;
 			children = (
 				94B2AE6F2B3740770081B1FE /* PequenoNetworking */,
-				94569E272B28EE64008494E1 /* FileLoaderIntegrationSpecs.swift */,
+				94569E272B28EE64008494E1 /* FileLoaderIntegrationSpec.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -482,7 +495,7 @@
 		94B2AE6F2B3740770081B1FE /* PequenoNetworking */ = {
 			isa = PBXGroup;
 			children = (
-				94B2AE702B3740900081B1FE /* PequenoNetworkingIntegrationSpecs.swift */,
+				94B2AE702B3740900081B1FE /* PequenoNetworkingIntegrationSpec.swift */,
 			);
 			path = PequenoNetworking;
 			sourceTree = "<group>";
@@ -599,6 +612,7 @@
 				94569E192B28EC93008494E1 /* Frameworks */,
 				94569E1A2B28EC93008494E1 /* Resources */,
 				8E35B626FC7682CEF7B31B91 /* [CP] Embed Pods Frameworks */,
+				9404C5872B43BD20001626C8 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -618,7 +632,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1510;
 				TargetAttributes = {
 					94341AF8238CCECF00BC8355 = {
 						CreatedOnToolsVersion = 11.2.1;
@@ -864,9 +878,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				94B2AE712B3740900081B1FE /* PequenoNetworkingIntegrationSpecs.swift in Sources */,
+				94B2AE712B3740900081B1FE /* PequenoNetworkingIntegrationSpec.swift in Sources */,
 				94569E5B2B30E776008494E1 /* SpecModels.swift in Sources */,
-				94569E282B28EE64008494E1 /* FileLoaderIntegrationSpecs.swift in Sources */,
+				94569E282B28EE64008494E1 /* FileLoaderIntegrationSpec.swift in Sources */,
 				94569E582B30E19D008494E1 /* SomeTestFunctions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -892,6 +906,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -941,7 +956,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -957,6 +972,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1000,7 +1016,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -1033,14 +1049,16 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = teamthick.utensils;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1068,14 +1086,16 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = teamthick.utensils;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1088,7 +1108,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Specs/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1098,6 +1118,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1110,7 +1133,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Specs/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1120,6 +1143,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1137,12 +1163,15 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 0.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = teamthick.IntegrationSpecs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -1162,12 +1191,15 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 0.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = teamthick.IntegrationSpecs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Utensils.xcodeproj/project.pbxproj
+++ b/Utensils.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		94872AF92915D20700D3528B /* Bundle+Utensils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94872AF82915D20700D3528B /* Bundle+Utensils.swift */; };
 		94872AFF2915D28E00D3528B /* Trunk+Utensils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94872AFE2915D28E00D3528B /* Trunk+Utensils.swift */; };
 		94B2AE712B3740900081B1FE /* PequenoNetworkingIntegrationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B2AE702B3740900081B1FE /* PequenoNetworkingIntegrationSpec.swift */; };
+		94BCF31C2B485F38008A5D78 /* FakePequenoNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94BCF31B2B485F37008A5D78 /* FakePequenoNetworking.swift */; };
 		94DB4641239479EF00D0C0A2 /* AppLaunchViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB4640239479EF00D0C0A2 /* AppLaunchViewControllerSpec.swift */; };
 		94FD50582B3B24770090455F /* URLRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94FD50572B3B24770090455F /* URLRequestBuilder.swift */; };
 		94FD505B2B3B26020090455F /* URLRequestBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94FD505A2B3B26020090455F /* URLRequestBuilderSpec.swift */; };
@@ -153,6 +154,7 @@
 		94872AF82915D20700D3528B /* Bundle+Utensils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Utensils.swift"; sourceTree = "<group>"; };
 		94872AFE2915D28E00D3528B /* Trunk+Utensils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Trunk+Utensils.swift"; sourceTree = "<group>"; };
 		94B2AE702B3740900081B1FE /* PequenoNetworkingIntegrationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PequenoNetworkingIntegrationSpec.swift; sourceTree = "<group>"; };
+		94BCF31B2B485F37008A5D78 /* FakePequenoNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePequenoNetworking.swift; sourceTree = "<group>"; };
 		94DB4640239479EF00D0C0A2 /* AppLaunchViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchViewControllerSpec.swift; sourceTree = "<group>"; };
 		94FD50572B3B24770090455F /* URLRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestBuilder.swift; sourceTree = "<group>"; };
 		94FD505A2B3B26020090455F /* URLRequestBuilderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestBuilderSpec.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 			children = (
 				9404C5702B431AD6001626C8 /* FakeClassicNetworkingEngine.swift */,
 				9404C56D2B4318BF001626C8 /* FakeNetworkingEngine.swift */,
+				94BCF31B2B485F37008A5D78 /* FakePequenoNetworking.swift */,
 				9404C5672B431602001626C8 /* FakeURLRequestBuilder.swift */,
 				9404C56A2B431814001626C8 /* FakeURLSessionExecutor.swift */,
 			);
@@ -820,6 +823,7 @@
 			files = (
 				94FD505D2B3B48280090455F /* URLSessionExecutor.swift in Sources */,
 				94569E302B29F596008494E1 /* FakeFileLoader.swift in Sources */,
+				94BCF31C2B485F38008A5D78 /* FakePequenoNetworking.swift in Sources */,
 				94FD50582B3B24770090455F /* URLRequestBuilder.swift in Sources */,
 				94569E372B2CB1EE008494E1 /* FileLoader+Utensils.swift in Sources */,
 				9404C5722B431AF6001626C8 /* FakeClassicNetworkingEngine.swift in Sources */,

--- a/Utensils.xcodeproj/xcshareddata/xcschemes/IntegrationSpecs.xcscheme
+++ b/Utensils.xcodeproj/xcshareddata/xcschemes/IntegrationSpecs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Utensils.xcodeproj/xcshareddata/xcschemes/Specs.xcscheme
+++ b/Utensils.xcodeproj/xcshareddata/xcschemes/Specs.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94341AF8238CCECF00BC8355"
-               BuildableName = "Utensils.framework"
-               BlueprintName = "Utensils"
-               ReferencedContainer = "container:Utensils.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -35,16 +19,6 @@
                BlueprintIdentifier = "944A0118238D7CBD00957702"
                BuildableName = "Specs.xctest"
                BlueprintName = "Specs"
-               ReferencedContainer = "container:Utensils.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94569E1B2B28EC93008494E1"
-               BuildableName = "IntegrationSpecs.xctest"
-               BlueprintName = "IntegrationSpecs"
                ReferencedContainer = "container:Utensils.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -67,15 +41,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "94341AF8238CCECF00BC8355"
-            BuildableName = "Utensils.framework"
-            BlueprintName = "Utensils"
-            ReferencedContainer = "container:Utensils.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
This update:

* Add missing `FakePequenoNetworking`
* Allows fakes to execute stored functions (completionHandlers) immediately using boolean flag
* Sets test targets to iOS deployment target to `15.0`
* Bumps `Quick` version to `7.3.0`